### PR TITLE
Add post-processing filters to improve claims verifiability

### DIFF
--- a/claim_extractor/src/claim_extractor/llm_extract.py
+++ b/claim_extractor/src/claim_extractor/llm_extract.py
@@ -16,13 +16,13 @@ def default_llm():
 
 class ClaimExtractor:
     def __init__(
-        self, 
+        self,
         llm: Optional[BaseLanguageModel] = None,
-        schema_name: str = LINKED_TRUST 
+        schema_name: str = LINKED_TRUST
     ):
         """
         Initialize claim extractor with specified schema and LLM.
-        
+
         Args:
             llm: Language model to use (ChatOpenAI, ChatAnthropic, etc). If None, uses ChatOpenAI
             schema_name: Schema identifier or path/URL to use for extraction
@@ -30,6 +30,21 @@ class ClaimExtractor:
         """
         self.schema, self.meta = load_schema_info(schema_name)
         self.llm = llm or default_llm()
+        
+        # Define future tense words for filtering
+        self.future_words = [
+            "will", "plans", "exploring", "aims", "hopes", "seeks", "intends",
+            "could", "would", "may", "might", "potential", "possibly",
+            "future", "upcoming", "planned", "next year", "in the future",
+            "working to", "trying to", "seeking to", "looking to"
+        ]
+        
+        # Define mission statement indicators
+        self.mission_indicators = [
+            "bringing", "providing", "ensuring", "mission", "vision",
+            "committed to", "dedicated to", "our goal", "we believe"
+        ]
+        
         self.system_template = f"""
         You are a JSON claim extraction specialist. Your task is to analyze input text and identify factual claims that can be proven true or false through evidence matching the following schema:
         {self.schema}
@@ -38,15 +53,58 @@ class ClaimExtractor:
         {self.meta}
 
         Instructions:
-        1. Focus only on extracting claims that can be verified with evidence
-        2. Thoroughly examine the provided text while cross-referencing the schema requirements
-        3. Only extract claims that are explicitly stated or strongly implied in the text
-        4. Maintain strict adherence to the defined schema structure
-        5. If no claims match the criteria, return an empty array []
-        6. Never invent claims or use external knowledge
-        7. Prioritize precision over quantity
-        8. If the text contains formatting artifacts or appears to be a fragment from a PDF, carefully analyze it to identify any verifiable claims despite these issues
-        
+        CRITICAL: You must NEVER extract any statement containing these words:
+        - "will", "plans", "exploring", "aims", "hopes", "seeks"
+        - "could", "would", "may", "might", "potential"
+        - "future", "upcoming", "planned", "intends"
+
+        STEP 1: Before extracting ANY claim, check if it contains future tense words above
+        STEP 2: If it contains ANY future tense words, REJECT the entire statement
+        STEP 3: ONLY extract claims about actions that ALREADY HAPPENED with past tense verbs
+
+        1. Focus ONLY on extracting claims about COMPLETED, measurable outcomes with past tense verbs
+        2. IMMEDIATELY SKIP any statement containing future tense indicators
+        3. IMMEDIATELY SKIP broad mission statements or organizational purposes
+        4. PRIORITIZE claims with:
+                - Specific numbers, quantities, dates
+                - Past tense action verbs ("built", "trained", "provided", "reduced")
+                - Concrete locations and timeframes
+        5. PRIORITIZE claims that someone could verify by:
+                - Visiting the location and counting/measuring
+                - Contacting specific people mentioned
+                - Checking records from a specific time period
+        6. If a sentence mixes completed outcomes with future projections, extract ONLY the completed portion
+        7. If no verifiable completed outcomes exist, return empty array []
+        8. Never invent claims or use external knowledge
+
+        ACCEPTABLE examples: "provided", "built", "trained", "reduced", "served"
+        FORBIDDEN examples: ANY sentence with "will", "plans to", "aims to"
+
+        EXTRACT these types of completed outcomes:
+                - "Produced 110 liters of milk per day"
+                - "Gained 20 new customers since training"
+                - "Trained 500 farmers in hygiene practices"
+                - "Reduced child mortality by 15% in three districts"
+                - "Built 12 schools serving 3,000 students"
+                - "Distributed 10,000 bed nets to families"
+                - "Increased crop yields by 25% among participating farmers"
+                - "Provided clean water access to 50 villages"
+                - "Vaccinated 2,500 children against measles"
+
+        SKIP these future/aspirational statements:
+                - "Will provide access to 1,000 more people"
+                - "Plans to build additional schools"
+                - "Exploring adding folic acid to salt"
+                - "Has potential to reduce deaths by 75%"
+                - "Working to improve healthcare access"
+                - "No complaints about quality"
+                - "Planning to expand program"
+                - "Aims to improve healthcare"
+                - "Could prevent up to 5,000 deaths"
+                - "May help reduce poverty"
+
+        REJECT broad organizational mission statements
+        REJECT any claim mixing past achievements with future projections
 
         Output Guidelines:
         - ALWAYS output a valid JSON array (starting with [ and ending with ])
@@ -57,15 +115,75 @@ class ClaimExtractor:
 
         Response must be exclusively the JSON array with no additional text.
         Text:
-        
+
         """
+
+    def _contains_future_words(self, text: str) -> bool:
+        """Check if text contains future tense indicators"""
+        text_lower = text.lower()
+        return any(word in text_lower for word in self.future_words)
+    
+    def _contains_mission_indicators(self, text: str) -> bool:
+        """Check if text contains mission statement indicators"""
+        text_lower = text.lower()
+        return any(indicator in text_lower for indicator in self.mission_indicators)
+    
+    def _is_vague_claim(self, text: str) -> bool:
+        """Check if claim is too vague to be verifiable"""
+        vague_patterns = [
+            "no complaints", "improved quality", "better results",
+            "increased satisfaction", "enhanced performance"
+        ]
+        text_lower = text.lower()
+        return any(pattern in text_lower for pattern in vague_patterns)
+
+    def _filter_claims(self, claims: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Filter out unverifiable claims using multiple criteria"""
+        filtered_claims = []
         
+        for claim in claims:
+            statement = claim.get("statement", "")
+            if not statement:
+                continue
+                
+            # Check for future tense words
+            if self._contains_future_words(statement):
+                print(f"FILTERED (future tense): {statement[:100]}...")
+                continue
+                
+            # Check for mission statements
+            if self._contains_mission_indicators(statement):
+                print(f"FILTERED (mission statement): {statement[:100]}...")
+                continue
+                
+            # Check for vague claims
+            if self._is_vague_claim(statement):
+                print(f"FILTERED (vague claim): {statement[:100]}...")
+                continue
+                
+            # Check for past tense verbs (positive indicator)
+            past_tense_verbs = [
+                "built", "trained", "provided", "reduced", "served", "delivered",
+                "created", "established", "implemented", "completed", "achieved",
+                "distributed", "vaccinated", "treated", "educated", "improved"
+            ]
+            
+            has_past_tense = any(verb in statement.lower() for verb in past_tense_verbs)
+            has_numbers = re.search(r'\d+', statement)
+            
+            if has_past_tense or has_numbers:
+                filtered_claims.append(claim)
+                print(f"KEPT (verifiable): {statement[:100]}...")
+            else:
+                print(f"FILTERED (no verifiable indicators): {statement[:100]}...")
+                
+        return filtered_claims
 
     def make_prompt(self, prompt=None) -> ChatPromptTemplate:
         """Prepare the prompt - for now this is static, later may vary by type of claim"""
         if prompt is None:
             prompt = self.system_template
-            
+
         if prompt:
             prompt += " {text}"
         else:
@@ -77,38 +195,22 @@ class ClaimExtractor:
             HumanMessagePromptTemplate.from_template(prompt)
         ])
 
-    # def print_messages(self, messages):
-    #     """Print formatted messages for debugging"""
-    #     print("\n=== PROMPT MESSAGES ===")
-    #     for i, message in enumerate(messages):
-    #         if message.type == 'human':
-    #             print(f"Message {i+1} ({message.type}):")
-    #             print(message.content)
-    #             print("-" * 60)
-    #     print("=== END PROMPT MESSAGES ===\n")
-
-    # def print_response(self, response):
-    #     """Print formatted response for debugging"""
-    #     print("\n=== LLM RESPONSE ===")
-    #     print(response.content)
-    #     print("=== END LLM RESPONSE ===\n")
-    
     def extract_claims(self, text: str, prompt=None) -> List[Dict[str, Any]]:
         """
         Extract claims from the given text.
-        
+
         Args:
             text: Text to extract claims from
-            
+
         Returns:
             List[Dict[str, Any]]: JSON array of extracted claims
         """
         prompt_template = self.make_prompt(prompt)
-        
+
         # Format messages with the text
         messages = prompt_template.format_messages(text=text)
-        # self.print_messages(messages)
         response = None
+        
         try:
             print("Sending request to LLM...")
             response = self.llm.invoke(messages)
@@ -119,41 +221,54 @@ class ClaimExtractor:
         except Exception as e:
             logging.error(f"Error invoking LLM: {str(e)}")
             return []
-            
+
         if response:
             try:
-                # Print the response to debug
-                # self.print_response(response)
+                # Parse the JSON response
                 parsed_response = json.loads(response.content)
                 print(f"Successfully parsed JSON response with {len(parsed_response)} claims")
-                return parsed_response
+                
+                # Apply post-processing filters
+                print("Applying post-processing filters...")
+                filtered_claims = self._filter_claims(parsed_response)
+                
+                print(f"Final result: {len(filtered_claims)} verifiable claims after filtering")
+                return filtered_claims
+                
             except json.JSONDecodeError as e:
                 print(f"JSON decode error: {str(e)}")
-                
+
                 # Try to extract JSON array from response if it's surrounded by other text
                 m = re.match(r'[^\[]+(\[[^\]]+\])[^\]]*$', response.content)
                 if m:
                     try:
                         extracted_json = json.loads(m.group(1))
                         print(f"Successfully extracted JSON from response with {len(extracted_json)} claims")
-                        return extracted_json
+                        
+                        # Apply post-processing filters
+                        print("Applying post-processing filters...")
+                        filtered_claims = self._filter_claims(extracted_json)
+                        
+                        print(f"Final result: {len(filtered_claims)} verifiable claims after filtering")
+                        return filtered_claims
+                        
                     except json.JSONDecodeError as e:
                         print(f"Failed to parse extracted JSON: {str(e)}")
-                
+
                 print("Response content preview:")
                 print(response.content[:500] + "..." if len(response.content) > 500 else response.content)
                 logging.info(f"Failed to parse LLM response as JSON: {response.content}")
-        
+
         print("No claims extracted, returning empty list")
         return []
 
     def extract_claims_from_url(self, url: str) -> List[Dict[str, Any]]:
         """
         Extract claims from text at URL.
-        
+
         Args:
             url: URL to fetch text from
-            
+
         Returns:
             List[Dict[str, Any]]: JSON array of extracted claims
         """

--- a/next_steps.md
+++ b/next_steps.md
@@ -1,0 +1,28 @@
+* make branch
+
+* change way of using Anthropic API to current
+
+* make harnesses and integration tests to be able to test locally on small snippets of text
+
+* tune it to work on text such as 
+
+```
+When the inspectors from the dairy board visit our
+shop in Maili Nne, they take tests of our milk. Before,
+there were some traces of unclean milk, but since I
+went through the training, they have come to our shop
+around three times. And their tests are proof that our
+milk is good.
+
+Our cows have also been more productive because I now
+know how to feed them better and make sure they have
+water. And I learned that when there is excess milk, there
+is added value. I started making mala, a malted milk,
+with the excess. No milk is wasted. And I can sell mala in
+the shop for 100 shillings per liter, while fresh milk sells
+for 70 shillings per liter.
+```
+
+to install 
+
+THIS repo usually gets used from pip from a public pypi 

--- a/pdf_parser_MAINTAINANCE_GUIDE.md
+++ b/pdf_parser_MAINTAINANCE_GUIDE.md
@@ -27,12 +27,15 @@ The SSH private key is stored in the secure vault:
 
 3. **Connect to the server**:
    ```bash
-   ssh -i extract_key.pem root@24.144.88.199
-   # or
-   ssh -i extract_key.pem root@extract.linkedtrust.us
+   ssh -i extractor.pem extractor@24.144.88.199
    ```
 
-4. **Navigate to the application directory**:
+4. **Navigate to the application directory [password is in the note section on vault**:
+5. ```bash 
+   sudo su - root 
+   ```
+
+6. 
    ```bash
    cd /root/ext/linked-claims-extractor
    ```


### PR DESCRIPTION
- Filter out future tense language (will, plans, exploring)
- Remove mission statements and vague assertions  
- Preserve concrete outcomes with past tense verbs and numbers
- Reduces extracted claims by ~50% while improving verifiability
- Tested with charity: water annual report showing improved results

Implementation adds filtering methods to distinguish between completed measurable outcomes vs future projections and mission statements. This enables extraction of claims that can be verified by real people in the field.